### PR TITLE
Add usage example instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The main entry point is `ScenarioExplorer`. Provide it with a `BaseChatModel` im
 
 ```python
 from langchain.chat_models import ChatOpenAI  # or any other model
+
 from explorer.scenario_explorer import ScenarioExplorer
 
 model = ChatOpenAI()
@@ -59,6 +60,19 @@ for frame in result:
 ```
 
 Each item in `result` is an `ActionFrame` describing the action performed, including element metadata and optional input text. Interruptions such as missing elements are also recorded.
+
+## Example
+
+An example CLI is provided in `example/run_explorer.py`. Pass your Anthropic
+API token and a text file describing the scenario:
+
+```bash
+python example/run_explorer.py <ANTHROPIC_TOKEN> /path/to/scenario.txt
+```
+
+The script runs the scenario against the currently connected emulator or device
+and writes the formatted results to `explore_result.json` in the working
+directory.
 
 ## Extending the project
 

--- a/example/run_explorer.py
+++ b/example/run_explorer.py
@@ -1,0 +1,43 @@
+"""Command line interface for running ScenarioExplorer with Anthropic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from langchain_community.chat_models import ChatAnthropic
+
+from explorer.scenario_explorer import ScenarioExplorer
+
+
+def main() -> None:
+    """Run ScenarioExplorer with the provided scenario file."""
+    parser = argparse.ArgumentParser(
+        description="Run ScenarioExplorer using Claude 3.5 Haiku"
+    )
+    parser.add_argument("token", help="Anthropic API token")
+    parser.add_argument("scenario_file", type=Path, help="Path to scenario text file")
+    args = parser.parse_args()
+
+    scenario = args.scenario_file.read_text(encoding="utf-8")
+
+    model = ChatAnthropic(
+        model_name="claude-3-5-haiku-latest",
+        anthropic_api_key=args.token,
+        temperature=0.0,
+        max_tokens=8000,
+    )
+
+    explorer = ScenarioExplorer(model)
+    result = explorer.explore(scenario)
+
+    output_path = Path.cwd() / "explore_result.json"
+    output_path.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(f"Results saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add instructions for running example CLI in README

## Testing
- `isort example/run_explorer.py`
- `black example/run_explorer.py`
- `ruff check example/run_explorer.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68666ee638cc83209848ab86abb13739