### PR TITLE
Fix imports after package move

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,5 @@ profile = "black"
 [tool.mypy]
 python_version = "3.11"
 strict = true
+exclude = ["example"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+# Add repository root to ``sys.path`` for local package imports during tests.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- fix test PYTHONPATH in conftest
- exclude example dir from mypy

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a9f61a488320823c22e7760fa03e