### PR TITLE
Add device key press support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Explorer is a toolkit for automating interaction scenarios with Android applicat
 - **Scenario parsing** – converts a free form description of a scenario into structured steps using a language model.
 - **Element navigation** – analyses an Android view hierarchy and finds elements by name or description using a language model.
 - **Scenario execution** – executes parsed steps against a real device using `uiautomator2` and collects action traces.
+- **Device key press** – allows pressing hardware and soft keys during exploration. Supported names: `home`, `back`, `left`, `right`, `up`, `down`, `center`, `menu`, `search`, `enter`, `delete`, `recent`, `volume_up`, `volume_down`, `volume_mute`, `camera`, `power`.
 
 ## Project layout
 


### PR DESCRIPTION
## Summary
- allow pressing hard/soft keys during scenario exploration
- only process known key names
- document supported key names in the README
- test ScenarioExplorer with invalid key names

## Testing
- `isort . && black .`
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686775ed39848320a56b2f421b6ffb02