### PR TITLE
Add token cost summary to example script

### DIFF
--- a/example/run_explorer.py
+++ b/example/run_explorer.py
@@ -7,8 +7,13 @@ import json
 from pathlib import Path
 
 from langchain_community.chat_models import ChatAnthropic
+from langchain_core.callbacks import get_usage_metadata_callback
 
 from explorer.scenario_explorer import ScenarioExplorer
+
+# Token pricing (per one million tokens)
+INPUT_COST_PER_M_TOKEN = 0.80
+OUTPUT_COST_PER_M_TOKEN = 4.0
 
 
 def main() -> None:
@@ -30,13 +35,27 @@ def main() -> None:
     )
 
     explorer = ScenarioExplorer(model)
-    result = explorer.explore(scenario)
+    with get_usage_metadata_callback() as cb:
+        result = explorer.explore(scenario)
+
+    usage = cb.usage_metadata
+    input_tokens = sum(v.get("input_tokens", 0) for v in usage.values())
+    output_tokens = sum(v.get("output_tokens", 0) for v in usage.values())
+    input_cost = input_tokens / 1_000_000 * INPUT_COST_PER_M_TOKEN
+    output_cost = output_tokens / 1_000_000 * OUTPUT_COST_PER_M_TOKEN
+    total_tokens = input_tokens + output_tokens
+    total_cost = input_cost + output_cost
 
     output_path = Path.cwd() / "explore_result.json"
     output_path.write_text(
         json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
     )
     print(f"Results saved to {output_path}")
+
+    print("Token usage:")
+    print(f"  input tokens: {input_tokens} cost: ${input_cost:.4f}")
+    print(f"  output tokens: {output_tokens} cost: ${output_cost:.4f}")
+    print(f"  total tokens: {total_tokens} cost: ${total_cost:.4f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- show token usage costs in `example/run_explorer.py`

## Testing
- `isort .`
- `black .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68677a4f27248320afa2f5aa37303192