### PR TITLE
Allow custom Anthropic URL in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ Each item in `result` is an `ActionFrame` describing the action performed, inclu
 ## Example
 
 An example CLI is provided in `example/run_explorer.py`. Pass your Anthropic
-API token and a text file describing the scenario:
+API token and a text file describing the scenario. A custom API URL can be
+provided with the optional `--api-url` flag:
 
 ```bash
-python example/run_explorer.py <ANTHROPIC_TOKEN> /path/to/scenario.txt
+python example/run_explorer.py <ANTHROPIC_TOKEN> /path/to/scenario.txt \
+    --api-url https://example.com/v1
 ```
 
 The script runs the scenario against the currently connected emulator or device

--- a/example/run_explorer.py
+++ b/example/run_explorer.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
-from langchain_community.chat_models import ChatAnthropic
+from langchain.chat_models import ChatAnthropic
 from langchain_core.callbacks import get_usage_metadata_callback
 
 from explorer.scenario_explorer import ScenarioExplorer
@@ -23,6 +23,12 @@ def main() -> None:
     )
     parser.add_argument("token", help="Anthropic API token")
     parser.add_argument("scenario_file", type=Path, help="Path to scenario text file")
+    parser.add_argument(
+        "--api-url",
+        dest="api_url",
+        help="Custom Anthropic API URL",
+        default=None,
+    )
     args = parser.parse_args()
 
     scenario = args.scenario_file.read_text(encoding="utf-8")
@@ -30,6 +36,7 @@ def main() -> None:
     model = ChatAnthropic(
         model_name="claude-3-5-haiku-latest",
         anthropic_api_key=args.token,
+        anthropic_api_url=args.api_url,
         temperature=0.0,
         max_tokens=8000,
     )

--- a/tests/test_element_navigator.py
+++ b/tests/test_element_navigator.py
@@ -1,7 +1,7 @@
 from typing import cast
 
-from langgraph.constants import END
-from uiautomator2.xpath import XPathError  # type: ignore[import-untyped]
+from langgraph.constants import END  # type: ignore[import-not-found]
+from uiautomator2.xpath import XPathError  # type: ignore[import-not-found]
 
 from explorer.element_navigator import AgentState, ElementNavigator
 

--- a/tests/test_scenario_explorer.py
+++ b/tests/test_scenario_explorer.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 import pytest
-from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models import BaseChatModel  # type: ignore[import-not-found]
 
 from explorer.scenario_explorer import (
     ActionType,


### PR DESCRIPTION
## Summary
- enable passing a custom `--api-url` to `run_explorer.py`
- mention the new optional flag in README example
- fix test imports for mypy
- correct ChatAnthropic import path

## Testing
- `ruff check`
- `isort example/run_explorer.py`
- `black example/run_explorer.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68677d97ff748320873f70ef1406b4a1