### PR TITLE
Add named CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,16 @@ Each item in `result` is an `ActionFrame` describing the action performed, inclu
 
 ## Example
 
-An example CLI is provided in `example/run_explorer.py`. Pass your Anthropic
-API token and a text file describing the scenario. A custom API URL can be
-provided with the optional `--api-url` flag:
+An example CLI is provided in `example/run_explorer.py`. Pass the path to a
+scenario file and optionally your Anthropic API token. A custom API URL can be
+provided with the optional `--api-url` flag. When `--token` is omitted the
+script falls back to the value of the `ANTHROPIC_API_KEY` environment
+variable:
 
 ```bash
-python example/run_explorer.py <ANTHROPIC_TOKEN> /path/to/scenario.txt \
+python example/run_explorer.py \
+    --scenario-file /path/to/scenario.txt \
+    --token <ANTHROPIC_TOKEN> \
     --api-url https://example.com/v1
 ```
 

--- a/example/run_explorer.py
+++ b/example/run_explorer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 from langchain.chat_models import ChatAnthropic
@@ -21,8 +22,20 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Run ScenarioExplorer using Claude 3.5 Haiku"
     )
-    parser.add_argument("token", help="Anthropic API token")
-    parser.add_argument("scenario_file", type=Path, help="Path to scenario text file")
+    parser.add_argument(
+        "--token",
+        help=(
+            "Anthropic API token. Defaults to the value of the ANTHROPIC_API_KEY"
+            " environment variable."
+        ),
+        default=os.getenv("ANTHROPIC_API_KEY"),
+    )
+    parser.add_argument(
+        "--scenario-file",
+        type=Path,
+        required=True,
+        help="Path to scenario text file",
+    )
     parser.add_argument(
         "--api-url",
         dest="api_url",

--- a/tests/test_element_navigator.py
+++ b/tests/test_element_navigator.py
@@ -1,7 +1,7 @@
 from typing import cast
 
-from langgraph.constants import END  # type: ignore[import-not-found]
-from uiautomator2.xpath import XPathError  # type: ignore[import-not-found]
+from langgraph.constants import END
+from uiautomator2.xpath import XPathError  # type: ignore[import-untyped]
 
 from explorer.element_navigator import AgentState, ElementNavigator
 

--- a/tests/test_scenario_explorer.py
+++ b/tests/test_scenario_explorer.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 import pytest
-from langchain_core.language_models import BaseChatModel  # type: ignore[import-not-found]
+from langchain_core.language_models import BaseChatModel
 
 from explorer.scenario_explorer import (
     ActionType,
@@ -29,9 +29,7 @@ class FakeDevice:
         self.stopped = False
 
     def xpath(self, xpath: str) -> "FakeSelector":
-        from explorer.scenario_explorer import (  # type: ignore[attr-defined]
-            XPathElementNotFoundError,
-        )
+        from uiautomator2 import XPathElementNotFoundError  # type: ignore[import-untyped]  # isort: skip
 
         if xpath == "//notfound":
             raise XPathElementNotFoundError("not found")


### PR DESCRIPTION
## Summary
- provide `--token` and `--scenario-file` args for `run_explorer.py`
- document the new CLI usage
- fix tests and mypy config

## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867933b5208832092b303890b12e564