### PR TITLE
Fix JSON serialization for explorer results

### DIFF
--- a/example/run_explorer.py
+++ b/example/run_explorer.py
@@ -52,7 +52,7 @@ def main() -> None:
         api_key=args.token,
         base_url=args.api_url,
         temperature=0.0,
-        max_tokens_to_sample=8000
+        max_tokens_to_sample=8000,
     )
     http_client_without_ssl_verification = httpx.Client(verify=False)
     model._client._client = http_client_without_ssl_verification
@@ -71,7 +71,8 @@ def main() -> None:
 
     output_path = Path.cwd() / "explore_result.json"
     output_path.write_text(
-        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+        json.dumps([frame.to_dict() for frame in result], ensure_ascii=False, indent=2),
+        encoding="utf-8",
     )
     print(f"Results saved to {output_path}")
 

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import List, Optional
 
@@ -81,3 +81,12 @@ class ActionFrame:
     screen: Optional[ScreenInfo]
     action: ActionInfo
     error: Optional[Error]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON serialisable representation of the frame."""
+
+        return {
+            "screen": asdict(self.screen) if self.screen else None,
+            "action": self.action.model_dump(),
+            "error": asdict(self.error) if self.error else None,
+        }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,29 @@
+import json
+from typing import cast
+
+from explorer.models import (
+    ActionFrame,
+    ActionInfo,
+    ActionType,
+    ElementInfo,
+    Error,
+    ScreenInfo,
+)
+
+
+def test_action_frame_to_dict() -> None:
+    frame = ActionFrame(
+        screen=ScreenInfo(name="main", description="", hierarchy="<hierarchy/>"),
+        action=ActionInfo(
+            element=ElementInfo(description="btn"), type=ActionType.CLICK
+        ),
+        error=Error(type="SomeError", message="oops"),
+    )
+    data = frame.to_dict()
+    screen = cast(dict[str, str], data["screen"])
+    action = cast(dict[str, str], data["action"])
+    error = cast(dict[str, str], data["error"])
+    assert screen["name"] == "main"
+    assert action["type"] == ActionType.CLICK
+    assert error["type"] == "SomeError"
+    json.dumps(data)  # Ensure serializable


### PR DESCRIPTION
## Summary
- add `to_dict` method on `ActionFrame` to produce serialisable data
- update CLI example to use `ActionFrame.to_dict`
- test `ActionFrame.to_dict`

## Testing
- `ruff check explorer example tests`
- `mypy explorer tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868d25f658483208a79bb72dfc4cb57