### PR TITLE
Enhance explorer example with model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ Each item in `result` is an `ActionFrame` describing the action performed, inclu
 ## Example
 
 An example CLI is provided in `example/run_explorer.py`. Pass the path to a
-scenario file and optionally your Anthropic API token. A custom API URL can be
-provided with the optional `--api-url` flag. When `--token` is omitted the
-script falls back to the value of the `ANTHROPIC_API_KEY` environment
-variable:
+scenario file as a positional argument. Optional flags allow selecting the
+underlying model (`haiku`, `4.1-mini` or `v3`) and specifying the API token and
+endpoint. When `--token` is omitted the script falls back to the value of the
+`ANTHROPIC_API_KEY` environment variable:
 
 ```bash
-python example/run_explorer.py \
-    --scenario-file /path/to/scenario.txt \
-    --token <ANTHROPIC_TOKEN> \
+python example/run_explorer.py /path/to/scenario.txt \
+    --model haiku \
+    --token <API_TOKEN> \
     --api-url https://example.com/v1
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,10 @@ jsonpatch==1.33
 jsonpointer==3.0.0
 langchain==0.3.26
 langchain-anthropic==0.3.17
+langchain-openai==0.3.27
 langchain-core==0.3.68
+openai==1.93.0
+deepseek==1.0.0
 langchain-text-splitters==0.3.8
 langgraph==0.5.1
 langgraph-checkpoint==2.1.0


### PR DESCRIPTION
## Summary
- update example CLI to support Anthropic, OpenAI and DeepSeek models
- allow selecting model via `--model` argument
- accept scenario file as positional argument
- track per-model token pricing
- document new usage in README
- add OpenAI and DeepSeek dependencies

## Testing
- `ruff check example/run_explorer.py`
- `mypy example/run_explorer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68691a44ba808320af09d68829c16447