### PR TITLE
Support actions without elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,13 @@ trace = result  # trace obtained from a previous run
 explorer.run_trace(trace)
 ```
 
-Each item in `result` is an `ActionFrame` describing the action performed, including element metadata and optional input text. Interruptions such as missing elements are also recorded.
+Each item in `result` is an `ActionFrame` describing the action performed. The
+`action` field stores an `ActionInfo` instance with details of the performed
+interaction.  When the action involves a UI element (e.g. click or text
+input) the `element` field contains its description.  For actions without an
+element, such as pressing hardware keys or swiping across the screen, this
+field is `null` and the `data` field holds the key name or swipe direction.
+Interruptions such as missing elements are also recorded.
 
 ## Example
 

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -32,13 +32,20 @@ class ElementInfo(BaseModel):
 
 
 class ActionInfo(BaseModel):
-    """Model of action with device."""
+    """Description of a single action to perform on the device."""
 
-    element: ElementInfo = Field(
-        description="Short description of element for action or name of the key"
+    element: Optional[ElementInfo] = Field(
+        None,
+        description=(
+            "Element to interact with. ``None`` for actions without a UI element"
+        ),
     )
     data: Optional[str] = Field(
-        None, description="Data required for an action, such as text for a text input"
+        None,
+        description=(
+            "Additional data required for the action. This is used for text input, "
+            "swipe direction or key name."
+        ),
     )
     type: ActionType = Field(
         ActionType.CLICK,

--- a/explorer/prompts/extract_step_by_step_scenario.md
+++ b/explorer/prompts/extract_step_by_step_scenario.md
@@ -1,8 +1,10 @@
 Here is a scenario of interaction with the application interface. Analyze it and complete the following tasks:
 1. Make a list of user actions with the application, save the order of actions described in the scenario
 2. For each action, specify:
-    - Short description of the element for interaction
-    - Data required for the action, if it needs it
+    - Short description of the element for interaction (set to `null` if the
+      action does not interact with a screen element)
+    - Data required for the action, if it needs it (text to input, swipe
+      direction or key name)
     - Type of interaction
       Possible types: `click`, `text_input`, `press_key`, `swipe_element`, `swipe_screen`
     

--- a/explorer/scenario_explorer.py
+++ b/explorer/scenario_explorer.py
@@ -74,7 +74,8 @@ class ScenarioExplorer:
         """Execute ``action`` on ``device`` without using the language model."""
 
         if action.type is ActionType.PRESS_KEY:
-            device.press(action.element.description)
+            key = cast(str, action.data)
+            device.press(key)
             action.status = ExecutionStatus.EXECUTED
             return
 
@@ -94,6 +95,7 @@ class ScenarioExplorer:
             action.status = ExecutionStatus.EXECUTED
             return
 
+        assert action.element is not None
         selector = device.xpath(cast(str, action.element.xpath))
 
         if action.type is ActionType.SWIPE_ELEMENT:
@@ -154,7 +156,7 @@ class ScenarioExplorer:
                 continue
 
             if action.type is ActionType.PRESS_KEY:
-                key = action.element.description
+                key = cast(str, action.data)
                 if key not in VALID_KEYS:
                     frame.error = Error(type="InvalidKeyError", message=None)
                     frame.screen = ScreenInfo(
@@ -172,6 +174,7 @@ class ScenarioExplorer:
                 continue
 
             try:
+                assert action.element is not None
                 info = cast(
                     dict[str, object],
                     element_navigator.find_element_info(action.element.description),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,3 +29,15 @@ def test_action_frame_to_dict() -> None:
     assert action["type"] == ActionType.CLICK
     assert error["type"] == "SomeError"
     json.dumps(data)  # Ensure serializable
+
+
+def test_action_frame_without_element() -> None:
+    frame = ActionFrame(
+        screen=None,
+        action=ActionInfo(data="home", type=ActionType.PRESS_KEY),
+        error=None,
+    )
+    data = frame.to_dict()
+    action = cast(dict[str, str], data["action"])
+    assert action["data"] == "home"
+    assert data["screen"] is None

--- a/tests/test_scenario_explorer.py
+++ b/tests/test_scenario_explorer.py
@@ -84,12 +84,8 @@ def test_explore(monkeypatch: pytest.MonkeyPatch) -> None:
     scenario = Scenario(
         actions=[
             ActionInfo(element=ElementInfo(description="btn1"), type=ActionType.CLICK),
-            ActionInfo(
-                element=ElementInfo(description="home"), type=ActionType.PRESS_KEY
-            ),
-            ActionInfo(
-                element=ElementInfo(description="bad"), type=ActionType.PRESS_KEY
-            ),
+            ActionInfo(data="home", type=ActionType.PRESS_KEY),
+            ActionInfo(data="bad", type=ActionType.PRESS_KEY),
             ActionInfo(
                 element=ElementInfo(description="input"),
                 data="hello",
@@ -149,11 +145,7 @@ def test_swipe_actions(monkeypatch: pytest.MonkeyPatch) -> None:
                 data="left",
                 type=ActionType.SWIPE_ELEMENT,
             ),
-            ActionInfo(
-                element=ElementInfo(description="screen"),
-                data="up",
-                type=ActionType.SWIPE_SCREEN,
-            ),
+            ActionInfo(data="up", type=ActionType.SWIPE_SCREEN),
         ]
     )
 
@@ -190,7 +182,7 @@ def test_run_trace(monkeypatch: pytest.MonkeyPatch) -> None:
         ActionFrame(
             screen=None,
             action=ActionInfo(
-                element=ElementInfo(description="home"),
+                data="home",
                 type=ActionType.PRESS_KEY,
                 status=ExecutionStatus.EXECUTED,
             ),
@@ -209,7 +201,6 @@ def test_run_trace(monkeypatch: pytest.MonkeyPatch) -> None:
         ActionFrame(
             screen=None,
             action=ActionInfo(
-                element=ElementInfo(description="screen"),
                 data="down",
                 type=ActionType.SWIPE_SCREEN,
                 status=ExecutionStatus.EXECUTED,


### PR DESCRIPTION
## Summary
- allow ActionInfo to omit element
- use ActionInfo.data for key names and swipe directions
- clarify prompt and README
- adjust logic for pressing keys and swiping
- update tests for the new data model

## Testing
- `isort explorer tests example/run_explorer.py`
- `black explorer tests example/run_explorer.py`
- `ruff check explorer tests example/run_explorer.py`
- `mypy explorer tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4b7031648320a0d015e75329797b