### PR TITLE
Update frame screen capture before each action

### DIFF
--- a/explorer/scenario_explorer.py
+++ b/explorer/scenario_explorer.py
@@ -166,10 +166,20 @@ class ScenarioExplorer:
                     )
                     action.status = ExecutionStatus.BROKEN
                     break
+                frame.screen = ScreenInfo(
+                    name="",
+                    description="",
+                    hierarchy=element_navigator.full_hierarchy,
+                )
                 self._perform_action(device, action)
                 continue
 
             if action.type is ActionType.SWIPE_SCREEN:
+                frame.screen = ScreenInfo(
+                    name="",
+                    description="",
+                    hierarchy=element_navigator.full_hierarchy,
+                )
                 self._perform_action(device, action)
                 continue
 

--- a/tests/test_scenario_explorer.py
+++ b/tests/test_scenario_explorer.py
@@ -112,6 +112,7 @@ def test_explore(monkeypatch: pytest.MonkeyPatch) -> None:
     assert trace[0].action.status == ExecutionStatus.EXECUTED
     assert trace[1].action.type == ActionType.PRESS_KEY
     assert trace[1].action.status == ExecutionStatus.EXECUTED
+    assert trace[1].screen and trace[1].screen.hierarchy == "<hierarchy/>"
     assert trace[2].error and trace[2].error.type == "InvalidKeyError"
     assert trace[2].action.status == ExecutionStatus.BROKEN
     # Following actions should remain pending due to early stop
@@ -159,6 +160,7 @@ def test_swipe_actions(monkeypatch: pytest.MonkeyPatch) -> None:
     width, height = device.window_size()
     margin = 100
     assert device.swiped_screen == [(width // 2, height - margin, width // 2, margin)]
+    assert trace[1].screen and trace[1].screen.hierarchy == "<hierarchy/>"
 
 
 def test_run_trace(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- record screen hierarchy before executing `PRESS_KEY` or `SWIPE_SCREEN` actions
- verify recorded hierarchy in scenario explorer tests

## Testing
- `ruff check .`
- `mypy explorer tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b814bd8988320ad7c41ab64676122